### PR TITLE
[P074] chore(deps): remove unused cryptography dependency from pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,6 @@ packages = [{ include = "secflow" }]
 python = "^3.11"
 pydantic = "^2.7"
 # M1 Dependencies
-cryptography = "^43.0"  # For security signing
 requests = "^2.32"      # For HTTP operations
 pyyaml = "^6.0"         # For YAML processing
 flask = "^3.0"          # For web framework


### PR DESCRIPTION
Patch: `.ai/PATCHES/P074-pyproject-dep-trim.md`

## Evidence
- `.ai/TASK.md`
- `.ai/REVIEW.md`
- `.ai/PATCHES/P074-pyproject-dep-trim.md`
- `pyproject.toml`

## Validation
- `Select-String -Path pyproject.toml -Pattern ''cryptography''` � no matches
- `Select-String -Path pyproject.toml -Pattern ''pyyaml''` � `pyyaml = "^6.0"` remains present
- `git diff --name-only -- pyproject.toml` � `pyproject.toml`

## Notes
- Phase 4 review approved for PR.
- Required checks `pyright`, `imports`, `contracts`, and `docs-health` still require CI confirmation.
