### PR TITLE
[P076] chore(ai): close split lifecycle and normalize coordination facts

### DIFF
--- a/.ai/CONTEXT.md
+++ b/.ai/CONTEXT.md
@@ -1,0 +1,34 @@
+﻿# Repository Context
+
+## Identity
+- Name: `secflow` (confirmed, `pyproject.toml`).
+- Version: `0.0.1` (confirmed, `pyproject.toml`).
+- Python target: `3.11.9` (confirmed, `.python-version`, CI).
+- Primary remote: `https://github.com/Juhertra/dev.git` (confirmed).
+
+## Co-Resident Tracks
+
+### Legacy App (confirmed)
+- Framework: Flask.
+- Purpose: web/API security testing workflow with findings storage, scanning integrations, triage UI, and reporting.
+- Main runtime files: `app.py`, `wsgi.py`, `web_routes.py`, `routes/`, `findings.py`, `store.py`, `nuclei_integration.py`.
+
+### Orchestrator Track (extracted - confirmed, 2026-03-15)
+- Extracted repo: `Juhertha/secflow-orchestrator` (Gate D complete).
+- Status in `Juhertha/dev` main: orchestrator package paths are absent; `Juhertha/dev` is legacy-only.
+
+## Toolchain
+- Packaging: Poetry (`pyproject.toml`), plus `requirements.txt` for docs-oriented installs.
+- Build/test runner: `Makefile` (`lint`, `type`, `imports`, `unit`, `test`, `health`).
+- CI: GitHub Actions under `.github/workflows/`.
+- Architecture boundary check: `.importlinter` (`packages.findings` isolation).
+
+## Split Status
+- Split lifecycle is complete (Gates A-E, 2026-03-17).
+- `Juhertha/dev` remains the legacy repo; `Juhertha/secflow-orchestrator` is the orchestrator repo.
+
+## Confirmed Risk Areas
+- Duplicate helper definitions exist in `store.py`.
+- `app.py` includes fallback API key behavior.
+- `app_config.json` contains developer-local paths and is committed.
+- Dependency declarations appear incomplete for some runtime imports.

--- a/.ai/ENTRYPOINTS.md
+++ b/.ai/ENTRYPOINTS.md
@@ -1,0 +1,209 @@
+# Entrypoints
+
+Evidence policy matches REPO_MAP.json: confirmed / inferred / uncertain.
+
+---
+
+## Primary Entrypoints Summary
+
+| Path | Kind | Track | Start Hint | Confidence |
+|---|---|---|---|---|
+| `app.py` | Flask dev server | Legacy App | `python app.py` | confirmed |
+| `wsgi.py` | WSGI entrypoint | Legacy App | WSGI server points at `wsgi:app` | confirmed |
+| `pattern_cli.py` | CLI | Legacy App | `python pattern_cli.py` | confirmed |
+| `tools/run_workflow.py` | CLI | Orchestrator | `python tools/run_workflow.py <recipe.yaml> [--dry-run]` | confirmed |
+| `tools/validate_recipe.py` | CLI | Orchestrator | `python tools/validate_recipe.py <recipe.yaml>` | confirmed |
+| `tools/workflow_to_mermaid.py` | CLI / utility | Orchestrator | `python tools/workflow_to_mermaid.py <recipe.yaml>` | confirmed |
+| `init_asvs.py` | Setup script | Legacy App | `python init_asvs.py` | confirmed |
+
+---
+
+## Execution Flow Overview
+
+### Legacy App Flow (confirmed)
+1. WSGI server or `python app.py` calls `create_app()` in `app.py`.
+2. `create_app()` registers `web_bp` (from `web_routes.py`) and `api_bp` (from `api_endpoints.py`; prefix `/api/v1`).
+3. `routes/__init__.py` registers 12 modular route handlers on `web_bp`.
+4. Flask route receives a request and calls helpers in `store.py`, `findings.py`, or scanner modules.
+5. Findings are normalized via `normalize_finding()` then written via `append_findings()`.
+6. Cache-bust (`_bust_vulns_cache()`) and metrics-rebuild hooks execute after write.
+7. UI/API responds from persisted state in `ui_projects/`.
+
+### Orchestrator Track Flow (historical / post-split)
+1. Historical CLI files (`tools/run_workflow.py`, `tools/validate_recipe.py`, `tools/workflow_to_mermaid.py`) still exist in `Juhertha/dev`.
+2. The orchestrator package implementations they depended on were extracted to `Juhertha/secflow-orchestrator` during Gate D.
+3. `Juhertha/dev` no longer carries `packages/runtime_core/`, `packages/storage/`, `packages/wrappers/`, or `packages/workflow_engine/` on `main`.
+4. Treat these CLIs as file references only in `Juhertha/dev`; active orchestrator execution and validation live in `Juhertha/secflow-orchestrator`.
+
+---
+
+## Non-Entrypoint Rule
+
+The following are **package modules** — they are imported by other code and are not intended for direct invocation.
+
+Historical note: orchestrator package modules under `packages/runtime_core/`, `packages/storage/`, `packages/wrappers/`, and `packages/workflow_engine/` were extracted to `Juhertha/secflow-orchestrator` and are absent from `Juhertha/dev` main.
+
+- `store.py`, `findings.py`, `core.py`, `cache.py`, `config.py`, `nuclei_wrapper.py`, `nuclei_integration.py`
+- `utils/findings_normalize.py` (has a `__main__` block, but it only runs `doctest.testmod()` — not a CLI)
+- `utils/dossier_management.py` (has a `__main__` block, but it runs a hardcoded one-off test — not a general CLI)
+- `packages/wrappers/manifest.py` (has a `__main__` block, but it runs example usage — not a general CLI)
+
+These files should be imported, not executed directly. The `__main__` guards present in some are development or doctest artifacts.
+
+---
+
+## 1. Legacy App — Runtime Entrypoints
+
+### `app.py`
+- **Kind:** Flask development server
+- **Start:** `python app.py` (binds port 5001)
+- **Role:** Application factory (`create_app()`); registers `web_bp` from `web_routes.py` and `api_bp` from `api_endpoints.py`; dev-only fallback API key `test-key-123`.
+- **sys.path:** None.
+- **Confidence:** confirmed
+
+### `wsgi.py`
+- **Kind:** WSGI production entrypoint
+- **Start:** Point WSGI server (e.g. gunicorn) at `wsgi:app`
+- **Role:** Imports `create_app` from `app.py`; creates and exposes the application object for production servers.
+- **sys.path:** None.
+- **Confidence:** confirmed
+
+---
+
+## 2. CLI Entrypoints (argparse, direct invocation)
+
+### `pattern_cli.py`
+- **Kind:** CLI
+- **Start:** `python pattern_cli.py`
+- **Role:** Pattern management CLI for the Legacy App.
+- **sys.path:** `sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))` at line 10 — inserts own directory (not repo root).
+- **Confidence:** confirmed
+
+### `tools/run_workflow.py`
+- **Kind:** Orchestrator CLI
+- **Start:** `python tools/run_workflow.py <recipe.yaml> [--dry-run]`
+- **Role:** Loads a workflow YAML and calls `packages/workflow_engine/executor.py`; handles `not_implemented` status gracefully (lines 113–116).
+- **sys.path:** `sys.path.insert(0, str(Path(__file__).parent.parent))` at line 16 — inserts repo root. **Split-sensitive.**
+- **Confidence:** confirmed
+
+### `tools/validate_recipe.py`
+- **Kind:** Orchestrator CLI
+- **Start:** `python tools/validate_recipe.py <recipe.yaml>`
+- **Role:** Validates a workflow YAML recipe. Contains real DAG dependency checking at lines 54–63 (checks unresolved inputs against all node outputs). Distinct from the scaffold-level stub in `packages/workflow_engine/validate_recipe.py`.
+- **sys.path:** `sys.path.insert(0, str(Path(__file__).parent.parent))` at line 15 — inserts repo root. **Split-sensitive.**
+- **Confidence:** confirmed
+
+### `tools/workflow_to_mermaid.py`
+- **Kind:** CLI / utility
+- **Start:** `python tools/workflow_to_mermaid.py <recipe.yaml>`
+- **Role:** Converts a YAML workflow recipe to a Mermaid flowchart diagram.
+- **sys.path:** Not confirmed.
+- **Confidence:** confirmed (has `__main__` guard; role inferred from name and usage in CI gate)
+
+### `tools/run_scan.py`
+- **Kind:** CLI
+- **Start:** `python tools/run_scan.py`
+- **Role:** Scan runner; exact argparse interface not confirmed.
+- **sys.path:** Not confirmed.
+- **Confidence:** inferred (has `__main__` guard; detailed interface not read)
+
+### `init_asvs.py`
+- **Kind:** Setup script
+- **Start:** `python init_asvs.py`
+- **Role:** Registers ASVS Nuclei templates into the application.
+- **sys.path:** `sys.path.insert(0, os.path.dirname(__file__))` at line 11 — inserts own directory.
+- **Confidence:** confirmed
+
+---
+
+## 3. Scripts (operational, one-time, or CI)
+
+All scripts in `scripts/` use `sys.path.insert` to add the repo root. All are **split-sensitive** if the split changes the repo root layout.
+
+| File | Role | Confidence |
+|---|---|---|
+| `scripts/export_findings_report.py` | Exports findings report (P6 export CLI) | confirmed |
+| `scripts/migrate_legacy_findings.py` | Migrates legacy findings data (P3) | confirmed |
+| `scripts/rebuild_vulns_caches.py` | Rebuilds vulnerability caches (P3) | confirmed |
+| `scripts/backfill_run_info.py` | Backfills missing Nuclei run info (P3) | confirmed |
+| `scripts/backfill_triage_defaults.py` | Backfills triage default values | confirmed |
+| `scripts/migrate_cve_placeholders.py` | One-time CVE placeholder cleanup | confirmed |
+| `scripts/benchmark_parsers.py` | Parser performance benchmark (M2 target) | confirmed |
+| `scripts/ci_gate.py` | CI gate check for Mermaid docs | confirmed |
+| `scripts/coverage_ratchet.py` | Enforces milestone coverage targets (M0=18% … M6=90%) | confirmed |
+| `scripts/demo_inmemory_store.py` | Development demo for in-memory storage adapter | confirmed |
+
+---
+
+## 4. Package Modules — Imported, Not Directly Executed
+
+These are historical package-module references for the extracted Orchestrator Track. They are not present on `Juhertha/dev` main and were moved to `Juhertha/secflow-orchestrator`.
+
+| Module | Role | Confidence |
+|---|---|---|
+| `packages/runtime_core/storage/storage_port.py` | Moved to `Juhertha/secflow-orchestrator`; absent from `Juhertha/dev` main | confirmed |
+| `packages/storage/adapters/memory.py` | Moved to `Juhertha/secflow-orchestrator`; absent from `Juhertha/dev` main | confirmed |
+| `packages/wrappers/base.py` | Moved to `Juhertha/secflow-orchestrator`; absent from `Juhertha/dev` main | confirmed |
+| `packages/workflow_engine/executor.py` | Moved to `Juhertha/secflow-orchestrator`; absent from `Juhertha/dev` main | confirmed |
+| `packages/workflow_engine/validate_recipe.py` | Moved to `Juhertha/secflow-orchestrator`; absent from `Juhertha/dev` main | confirmed |
+| `store.py` | Project/runtime state; JSON storage under `ui_projects/`; `RUNTIMES` in-process dict | confirmed |
+| `findings.py` | Finding validation and storage; `normalize_finding()` → `append_findings()` pipeline | confirmed |
+| `core.py` | Atomic JSON read/write helpers | confirmed |
+| `cache.py` | In-process TTL dict; `cached()` decorator | confirmed |
+| `config.py` | Reads/writes `app_config.json` | confirmed |
+| `nuclei_wrapper.py` | Nuclei binary subprocess wrapper; `NucleiResult` dataclass | confirmed |
+| `nuclei_integration.py` | Converts Nuclei results to findings; CVE validation | confirmed |
+
+---
+
+## 5. Utility `__main__` Guards — Not General CLIs
+
+These files have `if __name__ == "__main__"` blocks but are not general-purpose CLIs.
+
+| File | Behavior | Confidence |
+|---|---|---|
+| `utils/findings_normalize.py` | Runs `doctest.testmod()` — doctest runner only | confirmed |
+| `utils/dossier_management.py` | Runs a hardcoded one-off test with a specific UUID project ID — not a general CLI | confirmed |
+| `packages/wrappers/manifest.py` | Runs example usage — not a general CLI | confirmed |
+
+---
+
+## 6. Development / Proof-of-Concept Scripts
+
+These scripts exist for development verification and are not part of the operational workflow.
+
+| File | Role | Confidence |
+|---|---|---|
+| `tools/prove_runs_and_sse.py` | Proof script for run and SSE behavior | inferred |
+| `tools/phase1_verify.py` | Phase 1 verification script | inferred |
+| `tools/petstore_proof.py` | Petstore API proof script | inferred |
+| `tools/proof_final.py` | Final proof verification | inferred |
+| `tools/proof_phase2.py` | Phase 2 proof verification | inferred |
+
+---
+
+## 7. Test and Quality Commands (Makefile)
+
+Not direct entrypoints but the canonical way to invoke tests and quality checks.
+
+| Command | Role | Confidence |
+|---|---|---|
+| `make test` | Full test suite | confirmed |
+| `make unit` | Unit tests only | confirmed |
+| `make quick-test` | Fast subset (used in pre-commit) | confirmed |
+| `make coverage` | Test coverage report | confirmed |
+| `make lint` | Ruff linting | confirmed |
+| `make type` | Pyright type checking | confirmed |
+| `make imports` | import-linter boundary check | confirmed |
+| `make health` | Application health check | confirmed |
+
+---
+
+## Split-Sensitivity Summary
+
+Split lifecycle is complete (Gates A-E, 2026-03-17).
+
+- `Juhertha/dev` is now legacy-only.
+- Orchestrator packages were extracted to `Juhertha/secflow-orchestrator`.
+- Pre-split `sys.path` portability risk was resolved by P062 before Gate D completed.
+- Residual historical CLI files in `Juhertha/dev` should be treated as file references, not active orchestrator entrypoints.

--- a/.ai/MEMORY.md
+++ b/.ai/MEMORY.md
@@ -1,0 +1,77 @@
+﻿# Memory
+
+## Durable Confirmed Facts
+
+### Repository Identity
+- Package name is `secflow`, version `0.0.1`.
+- Python target is 3.11 (`.python-version` is `3.11.9`).
+- `Juhertha/dev` is now legacy-only; the Orchestrator Track was extracted to `Juhertha/secflow-orchestrator`.
+- Split lifecycle is complete (Gates A-E, 2026-03-17).
+- Durable split fact: `Juhertha/dev` is the legacy repo; `Juhertha/secflow-orchestrator` is the orchestrator repo.
+
+### Confirmed Entrypoints
+Full inventory is in `.ai/ENTRYPOINTS.md`. Key entries:
+- `app.py` — Flask development server (port 5001).
+- `wsgi.py` — WSGI production entrypoint; no CLI.
+- `pattern_cli.py` — pattern management CLI.
+- `tools/run_workflow.py` — orchestrator CLI; `--dry-run` flag; handles `not_implemented`.
+- `tools/validate_recipe.py` — recipe validation CLI; real DAG dependency checking at lines 54–63.
+- `tools/workflow_to_mermaid.py` — converts YAML recipe to Mermaid diagram.
+- `init_asvs.py` — ASVS Nuclei template setup script.
+- All files under `scripts/` — operational, migration, and CI scripts.
+
+### Confirmed Makefile Commands
+- `make test` — full test suite.
+- `make unit` — unit tests only.
+- `make quick-test` — fast subset (used in pre-commit).
+- `make coverage` — coverage report.
+- `make lint` — Ruff linting.
+- `make type` — Pyright type checking.
+- `make imports` — import-linter boundary check.
+- `make health` — application health check.
+
+### Confirmed Key Config Files
+- `pyproject.toml` — package metadata, dependencies, Poetry config.
+- `.python-version` — pins Python to `3.11.9`.
+- `app_config.json` — developer-local; gitignored in current working tree.
+- `.importlinter` — enforces `packages.findings` isolation boundary.
+- `.ruff.toml` — Ruff config; `select = []` (defaults only).
+- `pyrightconfig.json` — `typeCheckingMode = "basic"`; 58 checks explicitly disabled.
+- `.pre-commit-config.yaml` — ruff, ruff-format, pyright, pytest quick-test, docs-health.
+- `scripts/coverage_ratchet.py` — milestone coverage targets M0=18% through M6=90%.
+
+### Confirmed GitHub / CI Facts
+- Default branch: `master` (`confirmed`, live API 2026-03-07).
+- `main` branch protection is enabled (`confirmed`, live API 2026-03-07):
+  - required checks (`strict: true`): `pyright`, `imports`, `contracts`, `docs-health`
+  - required approving reviews: `1`
+  - `enforce_admins: false`
+- `master` is not protected (`confirmed`, live API 2026-03-07 returns `404 Branch not protected`).
+- CODEOWNERS `/*` rule: all root files require review from `@devex-lead`. Other CODEOWNERS paths use `/secflow/` prefix that does not match actual layout — those rules do not fire.
+- Required-check contexts `Compile Reports`, `Journals Lint`, `ruff (3.11.9)`, `unit (3.11.9)`, and `coverage (3.11.9)` are not in the current `main` required list (`confirmed`, live API 2026-03-07).
+- Python 3.12 matrix runs are explicitly non-blocking (`continue-on-error: true`).
+- `docs-validate.yml` and `security-monitoring.yml` target branch `main`, not `master` — those workflows do not fire on PRs to `master`.
+- Pre-merge local commands: `make lint`, `make type`, `make imports`, `make unit`, `make coverage`, `make health`, `pytest -q tests/contracts`.
+- Full reference: `.ai/GITHUB_SURFACE.md`, `.ai/CI_SURFACE.md`.
+- Governance cleanup snapshot on 2026-03-07 (live verified):
+  - PRs `#87`, `#89`, `#90`, `#92`, `#97` were closed as stale historical PRs.
+  - Issues `#91`, `#93`, `#94`, `#95`, `#96`, `#98`, `#99` were closed as historical workflow/board artifacts.
+  - PR `#101` (P010) merged 2026-03-07 via admin bypass.
+  - PR `#102` (P020) merged 2026-03-07 via admin bypass.
+  - PR `#103` (P050) merged 2026-03-07 (confirmed via API).
+  - CI debt issues `#48`, `#49`, `#63` remained open.
+
+### Confirmed Runtime Facts
+- Legacy API blueprint is registered at `/api/v1` in `api_endpoints.py:20`.
+- Runtime project data is stored under `ui_projects/` via `store.py` (`STORE_DIR`).
+- Findings storage uses a rolling cap (`MAX_FINDINGS = 2000`).
+- Import-linter enforces that `packages.findings` does not import `packages.runtime_core` or `packages.workflow_engine`.
+- Historical orchestrator fact: `packages/workflow_engine/executor.py` and `packages/workflow_engine/validate_recipe.py` were confirmed M1 implementations before the split; those package paths were later extracted to `Juhertha/secflow-orchestrator` and are absent from `Juhertha/dev` main.
+- Historical validation fact: P030 objectives were already met before extraction; active orchestrator execution/validation now belongs in `Juhertha/secflow-orchestrator`.
+
+## Open Questions
+1. `packages/storage/` ownership: resolved - moved to `Juhertha/secflow-orchestrator`.
+2. `packages/findings/` ownership: resolved - moved to `Juhertha/secflow-orchestrator`.
+3. `Juhertra/dev` rename question: resolved - repo remains `Juhertha/dev`.
+4. Orchestrator repo visibility: resolved - `Juhertha/secflow-orchestrator` is public.
+5. Whether `ui_projects/` runtime data should move to a local-only/ignored model (partial: `app_config.json` resolved by P020).

--- a/.ai/PLAN.md
+++ b/.ai/PLAN.md
@@ -1,0 +1,54 @@
+# Plan
+
+## Phase 1: Evidence Sync
+Status: completed
+- Re-read `.ai/*` and verify high-signal facts against repository files.
+
+## Phase 2: Consistency Cleanup
+Status: completed
+- Normalize terminology and headings.
+- Remove redundant wording and stale statements.
+- Ensure cross-file references stay correct.
+
+## Phase 3: Map and Patch Hygiene
+Status: completed
+- Keep `.ai/REPO_MAP.json` valid and evidence-labeled.
+- Keep `.ai/PATCHES/*` aligned with current terminology and risk model.
+
+## Phase 4: Review Log Update
+Status: completed
+- Record cleanup outcome in `.ai/REVIEW.md`.
+
+---
+
+## Phase 5: Engineering Work
+
+Status: completed
+
+All currently planned split-lifecycle and cleanup patches have been executed and merged:
+
+| Patch | Status |
+|---|---|
+| P010 | merged |
+| P020 | merged |
+| P030 | objectives already satisfied; no PR needed |
+| P040 | merged |
+| P050 | merged |
+| P060 | merged |
+| P061 | merged |
+| P062 | merged |
+| P063 | merged |
+| P064 | merged |
+| P065 | merged |
+| P066 | merged |
+| P067 | merged |
+| P068 | merged |
+| P069 | merged |
+| P070 | merged |
+| P071 | merged |
+| P072 | merged |
+| P073 | merged |
+| P074 | merged |
+| P075 | merged |
+
+Split lifecycle complete (Gates A-E, 2026-03-17). Remaining work is ordinary future patch work, not split-lifecycle execution.

--- a/.ai/REPO_BRAIN.md
+++ b/.ai/REPO_BRAIN.md
@@ -11,13 +11,10 @@
 - `findings.py` validates and stores findings with schema checks and rolling cap behavior.
 - `nuclei_wrapper.py` and `nuclei_integration.py` provide Nuclei scan execution and result conversion.
 
-### Orchestrator Track (confirmed M1 partial)
-- `packages/runtime_core/storage/storage_port.py` defines `StoragePort` protocol.
-- `packages/storage/adapters/memory.py` provides in-memory adapter implementation.
-- `packages/wrappers/base.py` provides tool wrapper protocol/ABC.
-- `packages/workflow_engine/executor.py` is an M1 implementation (825 lines): `execute_workflow()` returns `{"status": "completed"}` with full node execution, retry logic, and StoragePort integration (confirmed, read 2026-03-07).
-- `packages/workflow_engine/validate_recipe.py` is an M1 implementation (445 lines): `RecipeValidator` runs a 6-step pipeline - schema, pydantic, DAG cycle detection, references, node types, configurations (confirmed, read 2026-03-07).
-- `tools/run_workflow.py` and `tools/validate_recipe.py` are full CLIs. `run_workflow.py` supports `--dry-run`, `--execute`, `--parallel`, and `--test-sample` modes. `validate_recipe.py` performs real DAG dependency checking (confirmed, read 2026-03-07).
+### Orchestrator Track (extracted)
+- Orchestrator packages were extracted to `Juhertha/secflow-orchestrator` during Gate D.
+- `packages/runtime_core/`, `packages/storage/`, `packages/wrappers/`, and `packages/workflow_engine/` are absent from `Juhertha/dev` main.
+- `tools/run_workflow.py`, `tools/validate_recipe.py`, and `tools/workflow_to_mermaid.py` remain as legacy file references, but their package dependencies now live in `Juhertha/secflow-orchestrator`.
 
 ## Execution Flow (Current)
 
@@ -28,10 +25,10 @@
 4. Cache invalidation and metrics rebuild hooks execute.
 5. UI/API responds from persisted state.
 
-### Orchestrator Track Flow (confirmed + inferred)
-1. CLI loads workflow YAML.
-2. Recipe checks run via tool and package validation paths.
-3. Package executor is an M1 implementation; `execute_workflow()` returns `{"status": "completed"}` with `completed_nodes`, `total_findings`, and `execution_time` (confirmed, read 2026-03-07).
+### Orchestrator Track Flow (post-split status)
+1. Historical CLI files still exist in `Juhertha/dev`.
+2. The orchestrator package implementations they depended on were extracted to `Juhertha/secflow-orchestrator`.
+3. `Juhertha/dev` should be treated as legacy-only; active orchestrator work belongs in the orchestrator repo.
 
 ## Boundaries and Risks
 - Confirmed boundary: `packages.findings` must not import from `packages.runtime_core` or `packages.workflow_engine`.
@@ -39,4 +36,3 @@
   - duplicate helper definitions in `store.py`
   - fallback API key behavior in `app.py`
   - committed developer-local config paths
-  - `sys.path` manipulation in orchestrator-related modules/scripts

--- a/.ai/REPO_MAP.json
+++ b/.ai/REPO_MAP.json
@@ -1,5 +1,5 @@
 ﻿{
-  "generated_at": "2026-03-07",
+  "generated_at": "2026-03-17",
   "evidence_policy": {
     "confirmed": "Directly supported by repository files.",
     "inferred": "Derived from structure or naming; not explicitly declared.",
@@ -15,7 +15,7 @@
     ]
   },
   "repo_purpose": {
-    "summary": "Security testing toolkit with a functional Legacy App and an early-stage Orchestrator Track scaffold.",
+    "summary": "Legacy-only security testing toolkit; orchestrator code was extracted to Juhertha/secflow-orchestrator during the completed split lifecycle.",
     "confidence": "confirmed",
     "evidence": [
       "README.md",
@@ -123,21 +123,16 @@
     },
     {
       "name": "orchestrator_track",
-      "status": "scaffold",
+      "status": "extracted",
       "confidence": "confirmed",
-      "purpose": "Workflow orchestration package scaffold using ports/adapters style modules.",
+      "purpose": "Historical orchestrator track extracted to Juhertha/secflow-orchestrator during Gate D on 2026-03-15.",
       "confirmed_paths": [
-        "packages/runtime_core/",
-        "packages/workflow_engine/",
-        "packages/wrappers/",
-        "packages/storage/",
-        "workflows/sample-linear.yaml",
         "tools/run_workflow.py",
         "tools/validate_recipe.py"
       ],
       "current_limitations": [
-        "packages/workflow_engine/executor.py has duplicate WorkflowValidationError class (lines 88-90 and 289-291) and duplicate import os (lines 31 and 35) - tracked as P063",
-        "sys.path manipulation present in executor.py, tools/run_workflow.py, tools/validate_recipe.py, packages/storage/adapters/memory.py - tracked as R006/R007"
+        "Active orchestrator package code no longer lives in Juhertha/dev; use Juhertha/secflow-orchestrator for active orchestrator work.",
+        "Historical CLI files remain in Juhertha/dev, but their package dependencies were extracted during Gate D."
       ]
     }
   ],
@@ -348,7 +343,7 @@
     {
       "id": "R006",
       "area": "path_hacks",
-      "description": "sys.path manipulation is present in orchestrator-related modules/scripts.",
+      "description": "Historical sys.path manipulation risk was resolved by P062 before Gate D; no active orchestrator package path hacks remain on Juhertha/dev main.",
       "confidence": "confirmed",
       "evidence": [
         "packages/storage/adapters/memory.py",
@@ -359,7 +354,7 @@
     {
       "id": "R007",
       "area": "split_portability",
-      "description": "These sys.path-based imports are likely to complicate repository split portability.",
+      "description": "Historical split-portability concern resolved: orchestrator package code was extracted and the main pre-split sys.path hacks were removed by P062.",
       "confidence": "inferred",
       "evidence": [
         "packages/storage/adapters/memory.py",
@@ -373,34 +368,37 @@
     {
       "id": "U001",
       "question": "Final ownership of packages/storage after split?",
-      "status": "uncertain",
+      "status": "resolved",
       "evidence": [
-        "SPLIT_LEGACY_ORCHESTRATOR_ACTION_PLAN.md"
+        "Gate D execution",
+        "Juhertha/secflow-orchestrator"
       ]
     },
     {
       "id": "U002",
       "question": "Final ownership of packages/findings after split?",
-      "status": "uncertain",
+      "status": "resolved",
       "evidence": [
-        "SPLIT_LEGACY_ORCHESTRATOR_ACTION_PLAN.md"
+        "Gate D execution",
+        "Juhertha/secflow-orchestrator"
       ]
     },
     {
       "id": "U003",
       "question": "Will current dev repo be renamed during split?",
-      "status": "uncertain",
+      "status": "resolved",
       "evidence": [
-        "SPLIT_LEGACY_ORCHESTRATOR_ACTION_PLAN.md"
+        "Juhertha/dev remote state",
+        "Gate D / Gate E execution"
       ]
     },
     {
       "id": "U004",
-      "question": "Should app_config.json and runtime data move to a local-only/ignored model?",
-      "status": "uncertain",
+      "question": "Will the new orchestrator repo be private or public?",
+      "status": "resolved",
       "evidence": [
-        "app_config.json",
-        "store.py"
+        "Juhertha/secflow-orchestrator remote state",
+        "Gate D execution"
       ]
     }
   ]

--- a/.ai/SEARCH_GUIDE.md
+++ b/.ai/SEARCH_GUIDE.md
@@ -1,0 +1,105 @@
+# Repository Search Guide
+
+Concise navigation guide for the Coordination Pack.
+Aligned with `.ai/AGENTS.md`, `.ai/ENTRYPOINTS.md`, `.ai/REPO_BRAIN.md`, and `.ai/REPO_MAP.json`.
+
+## Scope And Terms
+- Use canonical terms from `.ai/AGENTS.md`: `Legacy App`, `Orchestrator Track`, `Coordination Pack`.
+- Keep evidence labels consistent: `confirmed`, `inferred`, `uncertain`.
+- Use this file for search/navigation only; execution rules remain in `.ai/SYSTEM_PROMPT.md` and agent prompts.
+
+## Search Hygiene
+
+Exclude noisy paths unless explicitly required:
+- `.venv/`
+- `.claude/worktrees/`
+- `patterns/community/nuclei-templates/`
+- `forChatGPT/`
+- `docs/`
+- `site/`
+
+Recommended command style:
+- Prefer `rg` when available.
+- Fallback in this repo shell: `Get-ChildItem ... | Select-String ...`
+
+PowerShell fallback example:
+```powershell
+Get-ChildItem -Recurse -File -Include *.py |
+  Where-Object { $_.FullName -notmatch '\\.venv\\|\\.claude\\worktrees\\|patterns\\community\\|forChatGPT\\|\\docs\\|\\site\\' } |
+  Select-String -Pattern "update_endpoint_dossier_by_key|get_endpoint_runs_by_key"
+```
+
+## Where To Look First
+
+### Legacy App
+- App wiring: `app.py`, `web_routes.py`, `routes/__init__.py`, `api_endpoints.py`
+- Storage/state: `store.py`, `core.py`, `config.py`
+- Findings pipeline: `utils/findings_normalize.py` -> `findings.py` -> `store._bust_vulns_cache()`
+- Endpoint key format: `utils/endpoints.py`
+- Nuclei flow: `nuclei_wrapper.py`, `nuclei_integration.py`
+
+### Orchestrator Track
+- Historical CLI files still present in `Juhertha/dev`: `tools/run_workflow.py`, `tools/validate_recipe.py`, `tools/workflow_to_mermaid.py`
+- Orchestrator packages and sample workflows were moved to `Juhertha/secflow-orchestrator` during Gate D and are absent from `Juhertha/dev` main
+- Search orchestrator package code in the orchestrator repo/worktree, not in `Juhertha/dev`
+
+## Entrypoint Reference
+
+Canonical entrypoint inventory is `.ai/ENTRYPOINTS.md`.
+Quick confirmed start points:
+- `app.py` (Flask dev server)
+- `wsgi.py` (WSGI app object)
+- `pattern_cli.py`
+- `tools/run_workflow.py`
+- `tools/validate_recipe.py`
+- `tools/workflow_to_mermaid.py`
+- `init_asvs.py`
+
+## Review History Lookup
+
+Read review history in this order:
+1. `TASK.md`
+2. top of `REVIEW.md`
+3. `REVIEW_INDEX.md`
+4. the specific archive file referenced by the index
+
+Open archive files only when needed for targeted historical lookup.
+
+## Patch-Oriented Search Checklist
+
+1. Read patch scope:
+- `.ai/PATCHES/<PatchID>.md`
+
+2. Read review context:
+- `.ai/REVIEW.md`
+
+3. Audit call sites:
+```powershell
+Get-ChildItem -Recurse -File -Include *.py |
+  Select-String -Pattern "<function_name>\\("
+```
+
+4. Detect duplicate definitions:
+```powershell
+Select-String -Path <file>.py -Pattern "^def <function_name>\\b"
+```
+
+5. Locate tests:
+```powershell
+Get-ChildItem tests -Recurse -File -Include *.py |
+  Select-String -Pattern "<function_name>|<module_name>"
+```
+
+## Known Repository-Specific Pitfalls
+- `.claude/worktrees/...` duplicates files and pollutes search results.
+- For recipe validation history in `Juhertha/dev`, `tools/validate_recipe.py` remains as a file reference; package validator paths were extracted to `Juhertha/secflow-orchestrator`.
+- `pytest.ini` is currently malformed; use `pytest -c pyproject.toml` when needed.
+- Historical `sys.path` split-portability risk was resolved by P062 before Gate D completed.
+
+## Related Coordination Files
+- Shared rules: `.ai/SYSTEM_PROMPT.md`
+- Role behavior: `.ai/prompts/CLAUDE_REVIEWER.md`, `.ai/prompts/CODEX_IMPLEMENTER.md`
+- Architecture summary: `.ai/REPO_BRAIN.md`
+- Machine map and risk IDs: `.ai/REPO_MAP.json`
+- GitHub governance (CODEOWNERS, PR template, labels, merge rules): `.ai/GITHUB_SURFACE.md`
+- CI workflow triggers and blocking/non-blocking classification: `.ai/CI_SURFACE.md`

--- a/.ai/TASK.md
+++ b/.ai/TASK.md
@@ -1,46 +1,56 @@
-﻿# Current Task
+# Current Task
 
 ## Status
 The coordination pack is complete. All `.ai/` files are consistent, evidence-labeled, and patch-ready.
 
-**P010 — Legacy store deduplication: completed and merged (PR #101, confirmed 2026-03-07).**
+**Split lifecycle complete (2026-03-17).** Gates A-E all complete. `Juhertha/dev` is legacy-only. `Juhertha/secflow-orchestrator` is the orchestrator repo.
 
-**P020 — Config and secrets hygiene: completed and merged (PR #102, confirmed 2026-03-07).**
+**Gate C - complete (2026-03-14).** PR `#114` merged. Merge commit `0f8f8a25d3e8cce4d4837d650df935814e141d61`.
 
-**P050 — CI and Branch Protection Alignment: completed and merged (PR #103, confirmed 2026-03-07).**
+**Gate D - complete (2026-03-15).** `Juhertra/secflow-orchestrator` created, rewritten history pushed, RSA key pair rotated, smoke checks completed. `lint-imports` remained deferred to Gate E.
+- Working clone: `D:\Lab\dev\.worktrees\gate-d-orchestrator`
 
-**P030 — Orchestrator Executor and Recipe Validation: objectives already met by prior M1 implementation (confirmed 2026-03-07, no PR needed).**
+**P069 - Residual Orchestrator Cleanup Before Gate D: completed and merged (PR #115, confirmed 2026-03-14). Merge commit `ce4f564cae7da66095e8fac82afc8468809d3e2e`.**
 
-**P060 — Coordination pack refresh: completed and merged (PR #104, confirmed 2026-03-08).**
+**P070 - Orchestrator CI Baseline and Import-Linter Configuration: completed and merged (PR `Juhertra/secflow-orchestrator#1`, merge commit `0afa816c`, confirmed 2026-03-15).**
 
-**P061 — CI workflow repair: completed and merged (PR #105, confirmed 2026-03-08).**
+**P071 - Orchestrator pyproject.toml Dependency Trim: completed and merged (PR `Juhertra/secflow-orchestrator#2`, merge commit `ab681e33dc166f42cbdb9cd4bc345bf30174f83c`, confirmed 2026-03-15).**
 
-**P063 — Executor defects: completed and merged (PR #106, confirmed 2026-03-13).**
+**P072 - Key Path Hardening in security/: completed and merged (PR `Juhertra/secflow-orchestrator#3`, merge commit `b548cd6c6227da867b4db9ab03c36939ffaa0e34`, confirmed 2026-03-15).**
 
-**P064 — Test suite repair: completed and merged (PR #107, confirmed 2026-03-13).**
+**P073 - Remove Residual Orchestrator Tests from Juhertra/dev main: completed and merged (PR `Juhertha/dev#116`, merge commit `e0b468a496e4ade3d28ce7851824ccc4236ae23c`, confirmed 2026-03-17). Deleted `tests/workflow/test_workflow_scaffolding.py`, `test_workflow_execution.py`, `test_workflow_integration.py`. Merged via operator-authorized `--admin` squash override.**
 
-**P062 — sys.path elimination: completed and merged (PR #108, confirmed 2026-03-14).**
+**P074 - Remove cryptography dep from Juhertha/dev pyproject.toml: completed and merged (PR `Juhertha/dev#118`, merge commit `b0830c73d99c6c1e1033ff8a70ff9f92bd8fbf66`, confirmed 2026-03-17). Removed `cryptography = "^43.0"`; `pyyaml` retained (active legacy use). Merged via operator-authorized `--admin` squash override.**
 
-**P065 — Agent Role Boundary Hardening: completed and merged (PR #110, confirmed 2026-03-14).**
+**P075 - CI Workflow Repair (security-monitoring.yml, security-scan.yml): completed and merged (PR `Juhertha/dev#117`, merge commit `aa4d57a2de26822840f865974e48e053f282a6a6`, confirmed 2026-03-17). Fixed upload/download-artifact@v3->v4; added continue-on-error to comment steps. Merged via operator-authorized `--admin` squash override.**
 
 ## Active Patch
-**P066 — Phase Ownership and Single-Step Execution** — implemented 2026-03-14, approved for PR, awaiting PR creation. Phases 2–4 complete. No PR opened yet.
 
-**P040 — Split Gate A Preflight: completed and merged (PR #109, confirmed 2026-03-14).** Artifact preserved in repository.
+**P076** â€” Split Lifecycle Close: normalize stale coordination-pack facts; record Gates Aâ€“E complete.
+Status: **Phase 3 complete - implementation applied; ready for Phase 4 review.**
+Spec: `.ai/PATCHES/P076-split-lifecycle-close.md`
+Scope: `.ai/` files only â€” `CONTEXT.md`, `ENTRYPOINTS.md`, `SEARCH_GUIDE.md`, `PLAN.md`, `MEMORY.md`, `REPO_BRAIN.md`, `REPO_MAP.json`, `TASK.md`.
+- Implementation summary: recorded in `REVIEW.md` under `## Implementation Summary - P076`
 
-**Gate B — Backup/Tag Creation: completed 2026-03-14.**
-- Tag `split-baseline-20260314-0206` pushed to `origin`.
-- Bundle `D:/Lab/dev-pre-split-20260314-0206.bundle` created and verified (local disk).
-- Restore clone healthy.
+**Gate E - Readiness analysis complete (2026-03-15). Ready to begin.**
+Gate E is executed as discrete numbered patches, not as a single gate.
+See `archive/REVIEW-archive-003.md` `## Gate E Readiness Analysis` for full evidence basis.
 
-## CI State (confirmed 2026-03-14)
-`main` branch protection clean: required checks `pyright`, `imports`, `contracts`, `docs-health` — all passing. One approving review required. `enforce_admins: false`. `unit` and `coverage` failing (pre-existing, not required).
+Patch execution order:
 
-## Candidate Patches
+**Batch A - Orchestrator baseline (sequential):**
+- **P070** (`secflow-orchestrator`): CI baseline + `.importlinter` - completed and merged (PR `#1`, 2026-03-15).
+- **P071** (`secflow-orchestrator`): remove `flask` from `pyproject.toml` - completed and merged (PR `#2`, 2026-03-15).
 
-No candidate patches remain.
+**Batch B - Orchestrator security (after P070 CI):**
+- **P072** (`secflow-orchestrator`): key path hardening in `security/plugin_loader.py` and `security/create_sample_plugins.py` - **completed and merged (PR `#3`, 2026-03-15).**
 
-Next authorized action: Gate C (legacy hard-boundary branch) requires explicit Gate C authorization from operator. **Prerequisite:** unresolved ownership decisions (packages/storage, packages/findings, packages/plugins, security/, shared docs, pyproject.toml, .github/) must be resolved in writing before Gate C can proceed.
+**Batch C - Legacy cleanup (independent; can proceed at any time):**
+- **P073** (`Juhertha/dev`): remove residual orchestrator tests from `main` â€” **completed and merged (PR `#116`, 2026-03-17).**
+- **P074** (`Juhertha/dev`): remove `cryptography` dep (scope narrowed; `pyyaml` retained, active use confirmed) â€” **completed and merged (PR `#118`, 2026-03-17).**
+- **P075** (`Juhertha/dev`): CI workflow audit â€” **completed and merged (PR `#117`, 2026-03-17).**
+
+**Batch C complete. All 3 patches merged.**
 
 ## Standing Rules
 - Separate `confirmed` from `inferred` and `uncertain`.


### PR DESCRIPTION
[P076] closes the split lifecycle coordination cleanup described in `.ai/PATCHES/P076-split-lifecycle-close.md`.

## Evidence
- `.ai/PATCHES/P076-split-lifecycle-close.md`
- `.ai/TASK.md`
- `.ai/REVIEW.md`
- `.ai/CONTEXT.md`
- `.ai/ENTRYPOINTS.md`
- `.ai/SEARCH_GUIDE.md`
- `.ai/PLAN.md`
- `.ai/MEMORY.md`
- `.ai/REPO_BRAIN.md`
- `.ai/REPO_MAP.json`

## Validation
- `Select-String -Path .ai\CONTEXT.md,.ai\MEMORY.md,.ai\PLAN.md,.ai\ENTRYPOINTS.md,.ai\SEARCH_GUIDE.md,.ai\REPO_BRAIN.md -Pattern "scaffold state|draft-only|gate-controlled"` -> no matches
- `Get-Content .ai\REPO_MAP.json -Raw | ConvertFrom-Json | Out-Null; "valid"` -> `valid`
- `git status --short -- .ai/CONTEXT.md .ai/ENTRYPOINTS.md .ai/SEARCH_GUIDE.md .ai/PLAN.md .ai/MEMORY.md .ai/REPO_BRAIN.md .ai/REPO_MAP.json .ai/TASK.md` -> scoped to the eight P076 files
